### PR TITLE
fix mod loading on clientside

### DIFF
--- a/src/main/java/jss/bugtorch/util/LoadedMods.java
+++ b/src/main/java/jss/bugtorch/util/LoadedMods.java
@@ -1,6 +1,8 @@
 package jss.bugtorch.util;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.relauncher.Side;
 import net.minecraft.server.MinecraftServer;
 
 public class LoadedMods {
@@ -10,8 +12,10 @@ public class LoadedMods {
     public static boolean thaumcraftLoaded;
 
     public static void detectBukkit() {
-    	String serverModName = MinecraftServer.getServer().getServerModName();
-        bukkitLoaded = (serverModName.contains("cauldron") || serverModName.contains("mcpc"));
+        if(FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER) {
+            String serverModName = MinecraftServer.getServer().getServerModName();
+            bukkitLoaded = (serverModName.contains("cauldron") || serverModName.contains("mcpc"));
+        }
     }
 
     public static void detectLoadedMods() {


### PR DESCRIPTION
Check for Bukkit assumed it was running on a server, causing an NPE on clients and making mixin injection fail.