### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,21 +1,17 @@
 {
-	"modListVersion": 2,
-	"modList": [{
-		"modid": "${modId}",
-		"name": "${modName}",
-		"description": "Backports a small handful of features that don't add new things, fixes some bugs, and does other stuff.",
-		"version": "${modVersion}",
-		"mcversion": "${minecraftVersion}",
-		"url": "https://github.com/GTNewHorizons/BugTorch",
-		"updateUrl": "",
-		"authorList": ["jss2a98aj"],
-		"credits": "",
-		"logoFile": "",
-		"screenshots": [],
-		"parent": "",
-		"requiredMods": ["gtnhmixins@[2.0.0,)"],
-		"dependencies": ["gtnhmixins@[2.0.0,)", "Thaumcraft", "temperateplants", "VillageNames", "witchery"],
-		"dependants": [],
-		"useDependencyInformation": true
-	}]
+  "modListVersion": 2,
+  "modList": [{
+    "modid": "${modId}",
+    "name": "${modName}",
+    "description": "Backports a small handful of features that don't add new things, fixes some bugs, and does other stuff.",
+    "version": "${modVersion}",
+    "mcversion": "${minecraftVersion}",
+    "url": "https://github.com/GTNewHorizons/BugTorch",
+    "updateUrl": "",
+    "authorList": ["jss2a98aj"],
+    "credits": "",
+    "logoFile": "",
+    "screenshots": [],
+    "parent": ""
+  }]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.